### PR TITLE
Add PaddleOCR license scanner

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,11 +5,13 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import NotFound from "@/pages/not-found";
 import Home from "@/pages/home";
+import LicenseOCR from "@/pages/license-ocr";
 
 function Router() {
   return (
     <Switch>
       <Route path="/" component={Home} />
+      <Route path="/license-ocr" component={LicenseOCR} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/pages/license-ocr.tsx
+++ b/client/src/pages/license-ocr.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+
+export default function LicenseOCR() {
+  const [file, setFile] = useState<File | null>(null);
+  const [result, setResult] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files && e.target.files[0];
+    setFile(f || null);
+  };
+
+  const scan = async () => {
+    if (!file) return;
+    const form = new FormData();
+    form.append("file", file);
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch("/api/paddle-ocr", {
+        method: "POST",
+        body: form,
+      });
+      if (!res.ok) {
+        const txt = await res.text();
+        throw new Error(txt || res.statusText);
+      }
+      const data = await res.json();
+      if (data.error) {
+        setError(data.error);
+      } else {
+        setResult(data.data);
+      }
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-semibold mb-4">Driver License OCR</h1>
+      <input type="file" accept="image/*" onChange={handleFileChange} />
+      <button
+        className="border px-4 py-1 ml-2"
+        onClick={scan}
+        disabled={!file || loading}
+      >
+        {loading ? "Scanning..." : "Scan"}
+      </button>
+      {error && <p className="text-red-500 mt-4">{error}</p>}
+      {result && (
+        <pre className="bg-gray-100 p-2 mt-4 rounded text-sm">
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/server/paddle_ocr_driver.py
+++ b/server/paddle_ocr_driver.py
@@ -1,0 +1,33 @@
+import sys
+import json
+from paddleocr import PaddleOCR
+
+
+def extract_fields(text_lines):
+    data = {"name": "", "dob": "", "trn": "", "nationality": ""}
+    for line in text_lines:
+        lower = line.lower()
+        if "name" in lower and not data["name"]:
+            data["name"] = line.split(":")[-1].strip()
+        elif ("dob" in lower or "date of birth" in lower) and not data["dob"]:
+            data["dob"] = line.split(":")[-1].strip()
+        elif "trn" in lower and not data["trn"]:
+            data["trn"] = line.split(":")[-1].strip()
+        elif "nationality" in lower and not data["nationality"]:
+            data["nationality"] = line.split(":")[-1].strip()
+    return data
+
+
+def main(path):
+    ocr = PaddleOCR(use_angle_cls=True, lang="en")
+    result = ocr.ocr(path, cls=True)
+    lines = [res[1][0] for res in result[0]] if result else []
+    data = extract_fields(lines)
+    print(json.dumps(data))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(json.dumps({"error": "No image path provided"}))
+        sys.exit(1)
+    main(sys.argv[1])

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,6 +3,9 @@ import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import multer from "multer";
 import { processImagesWithOpenAI } from "./openai-service";
+import { spawn } from "child_process";
+import fs from "fs";
+import path from "path";
 
 // Extend the Express Request interface to support multer's req.files
 // Note: We're not overriding the original definition, just adding a custom property
@@ -89,6 +92,51 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(500).json({
           error: error.message || "An error occurred while processing the images",
         });
+      }
+    }
+  );
+
+  // OCR Driver License with PaddleOCR
+  app.post(
+    "/api/paddle-ocr",
+    upload.single("file"),
+    async (req: Request, res: Response) => {
+      try {
+        const file = req.file as Express.Multer.File | undefined;
+        if (!file) {
+          return res.status(400).json({ error: "No image file uploaded" });
+        }
+
+        const tempPath = path.join("/tmp", `ocr_${Date.now()}_${file.originalname}`);
+        fs.writeFileSync(tempPath, file.buffer);
+
+        const script = path.join(__dirname, "paddle_ocr_driver.py");
+        const proc = spawn("python3", [script, tempPath]);
+
+        let out = "";
+        let err = "";
+
+        proc.stdout.on("data", (d) => {
+          out += d.toString();
+        });
+        proc.stderr.on("data", (d) => {
+          err += d.toString();
+        });
+
+        proc.on("close", (code) => {
+          fs.unlinkSync(tempPath);
+          if (code !== 0) {
+            return res.status(500).json({ error: err || "OCR process failed" });
+          }
+          try {
+            const data = JSON.parse(out);
+            return res.json({ data });
+          } catch (e) {
+            return res.status(500).json({ error: "Invalid OCR output" });
+          }
+        });
+      } catch (error: any) {
+        return res.status(500).json({ error: error.message });
       }
     }
   );


### PR DESCRIPTION
## Summary
- add Python script using PaddleOCR to extract driver license fields
- support `/api/paddle-ocr` route in server
- add simple React page with file upload to call the new OCR endpoint
- include route in app router

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node', 'vite/client')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68586527ab708332aea522d4c4c573d4